### PR TITLE
Improve GitHub Actions for Maintainability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - '2.6'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-task default: %i[spec rubocop]
+task default: %i[spec]

--- a/lib/m_logger.rb
+++ b/lib/m_logger.rb
@@ -10,7 +10,6 @@ class MLogger < ::Logger
   def initialize(logdev, shift_age = 0, shift_size = 1_048_576, level: DEBUG,
                  progname: nil, formatter: nil, datetime_format: nil,
                  binmode: false, shift_period_suffix: "%Y%m%d")
-
     self.level = level
     self.progname = progname
     @default_formatter = Formatter.new


### PR DESCRIPTION
### Summary

The maintainability of GitHub Actions has been improved.

As the test on Ci fails on a specific Ruby version, `fail-fast: false` has been introduced to distinguish the exact cause.
Also, I renamed the `build` with `test` to more accurately reflect the contents.
Finally, RuboCop has been removed from the default CI task to reflect the objective of coding guideline. (The more similar the code is to the original logger, the better the code is.)

In order for the good maintainability this PR will be merged if majority of Ruby versions let the test pass.

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

