### PR TITLE
Add dependency to logger for its migration to bundled gem

### DIFF
--- a/m_logger.gemspec
+++ b/m_logger.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "logger"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
### Summary

As reported in https://bugs.ruby-lang.org/issues/20309, the `logger` would be bundled gem from Ruby 3.5.
In order to be compatible with that, I have added the dependency.

### Other Information

### Checklist

* [ ] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

